### PR TITLE
Added support for large file uploads and downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,5 +3,9 @@ DiscordSlice is a program that allows you to easily upload large files to Discor
 
 ## Current Issues
 
-- The program crashes when files take longer than 15 minutes to upload or download, as an interaction only lasts for 15 minutes. A possible solution would be to use `ctx` instead of interactions.
 - Media files such as `mp4` or `mp3` get corrupted when uploaded, as they need to be split differently to avoid corruption.
+
+## Todo's
+
+- Add a feature to delete files
+- Doku

--- a/commandhandler.py
+++ b/commandhandler.py
@@ -27,6 +27,7 @@ class Commandhandler(commands.Cog):
 
     async def upload(self, ctx: commands.Context, filepath: str):
         """command to upload files"""
+        await ctx.reply("Working on Upload ↓")
         await self.upload_file.main(ctx, filepath)
 
     @commands.hybrid_command(

--- a/handlers/download_file.py
+++ b/handlers/download_file.py
@@ -55,7 +55,7 @@ class Download_Service():
         self.logger.info("All files downloaded successfully")
         await message.edit(content="All files downloaded successfully")
 
-    async def merge_files(self, ctx, message, channel_id):
+    async def merge_files(self, message, channel_id):
         input_files = os.listdir(f"files/download/{channel_id}")
         if not input_files:
             self.logger.info("No input files found")
@@ -106,13 +106,15 @@ class Download_Service():
 
 
     async def main(self, ctx, file:str):
-        message = await ctx.send("Working on Download...")
+        first_msg = await ctx.send("Working on Download ↓")
         os.makedirs("files/download", exist_ok=True)
         file_id = await self.get_file_channel_id(ctx, file)
         if file_id != None:
+            text_channel = ctx.channel
+            message = await text_channel.send("Preparing download")
             self.logger.info("Found file in the channel with the id %s", file_id)
             await self.download_files(ctx, message, file_id)
-            await self.merge_files(ctx, message, file_id)
+            await self.merge_files(message, file_id)
         else:
             self.logger.info("Didnt find any file for the input: %s", file)
-            await message.edit(content=f"Didnt find any file for the input: {file}")
+            await first_msg.edit(content=f"Didnt find any file for the input: {file}")

--- a/handlers/upload_file.py
+++ b/handlers/upload_file.py
@@ -2,6 +2,7 @@ import os
 import shutil
 
 import discord
+from discord.ext import commands
 from handlers.database_handler import Hybrid_DB_handler
 
 from logging_formatter import ConfigLogger
@@ -98,8 +99,9 @@ class Upload_Service():
         else:
             return f"{size_bytes} bytes"
 
-    async def main(self, ctx, path):
-        message = await ctx.send("Working on Upload...")
+    async def main(self, ctx:commands.Context, path):
+        text_channel = ctx.channel
+        message = await text_channel.send("Preparing upload")
         os.makedirs('files/upload', exist_ok=True)
         if os.path.exists(path):
             success = self.split_file(path)


### PR DESCRIPTION
This commit addresses the issue of errors being thrown when uploading or downloading large files that took more than 15 minutes, due to the invalidation of the ctx session token.