### PR TITLE
Fixed corrupt media files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,6 @@
 # DiscordSlicer
 DiscordSlice is a program that allows you to easily upload large files to Discord by slicing them up into 8MB parts. Once the files are uploaded, you can merge the parts back together again and download the complete file.
 
-## Current Issues
-
-- Media files such as `mp4` or `mp3` get corrupted when uploaded, as they need to be split differently to avoid corruption.
-
 ## Todo's
 
 - Add a feature to delete files

--- a/handlers/database_handler.py
+++ b/handlers/database_handler.py
@@ -61,6 +61,12 @@ class Hybrid_DB_handler:
             return self.cloud_db.find_name_by_channel_id(channel_id)
         else:
             return self.local_db.find_name_by_channel_id(channel_id)
+
+    def find_fullname_by_channel_id(self, channel_id:int):
+        if self.use_cloud_database:
+            return self.cloud_db.find_fullname_by_channel_id(channel_id)
+        else:
+            return self.local_db.find_fullname_by_channel_id(channel_id)
     
 class FileData:
     def __init__(self, id, user_id, channel_id, file_name, file_size, file_type):
@@ -130,6 +136,12 @@ class Local_DB_Manager:
         file = session.query(SavedFile).filter_by(channel_id=channel_id).first()
         session.close()
         return file.file_name if file else "No file found"
+    
+    def find_fullname_by_channel_id(self, channel_id):
+        session = self.session_maker()
+        file = session.query(SavedFile).filter_by(channel_id=channel_id).first()
+        session.close()
+        return f"{file.file_name}.{file.file_type}" if file else "No file found"
 
 
 class Cloud_DB_Manager():
@@ -185,3 +197,10 @@ class Cloud_DB_Manager():
     def find_name_by_channel_id(self, channel_id):
         result = self.collection.find_one({"channel_id": channel_id}, {"file_name": 1})
         return result.get("file_name", "No file found")
+
+    def find_fullname_by_channel_id(self, channel_id):
+        result = self.collection.find_one({"channel_id": channel_id}, {"file_name": 1, "file_type": 1})
+        file_name = result.get("file_name", "")
+        file_type = result.get("file_type", "")
+        full_file_name = file_name + '.' + file_type
+        return full_file_name or "No file found"

--- a/handlers/download_file.py
+++ b/handlers/download_file.py
@@ -56,23 +56,20 @@ class Download_Service():
         await message.edit(content="All files downloaded successfully")
 
     async def merge_files(self, message, channel_id):
-        input_files = os.listdir(f"files/download/{channel_id}")
+        input_files = sorted(os.listdir(f"files/download/{channel_id}"), key=lambda x: int(x.split("_")[-1]))
         if not input_files:
             self.logger.info("No input files found")
             await message.edit(content="No input files found")
             return False
 
-        first_file = input_files[0]
-        name, extension = os.path.splitext(first_file)
-        extension = extension.split("_")[0]
-        output_filename = name + extension
+        output_filename = self.db_handler.find_fullname_by_channel_id(channel_id)
         output_path = Path(os.path.expanduser("~/Downloads")) / output_filename
-
-        with open(output_path, "wb") as output_file:
-            for input_file in input_files:
+        
+        with open(output_path, 'wb') as f:
+            for i, input_file in enumerate(input_files):
                 input_path = f"files/download/{channel_id}/{input_file}"
-                with open(input_path, "rb") as input_file:
-                    shutil.copyfileobj(input_file, output_file)
+                with open(input_path, 'rb') as chunk_file:
+                    f.write(chunk_file.read())
 
         self.logger.info("Successfully merged files and saved it in the downloads folder")
         await message.edit(content="Successfully merged files and saved it in the downloads folder")


### PR DESCRIPTION
Addressed an issue where media files that were split and merged would only play until the end of the first chunk. To fix this, it is sorting the files before merging the chunks together.